### PR TITLE
Add CI workflow (fixes #46)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,29 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew SetupCIWorkspace build
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Package
+        path: build/libs


### PR DESCRIPTION
Adds a standard Github Actions workflow that builds the mod using Gradle and uploads the resulting jar ([example run](https://github.com/makamys/Backhand/actions/runs/3990445116)).